### PR TITLE
Prioritize perfect matches in card search (Issue #3)

### DIFF
--- a/apps/api/src/data.ts
+++ b/apps/api/src/data.ts
@@ -47,9 +47,36 @@ export function searchCards(
       card.text.toLowerCase().includes(searchTerm)
   );
 
+  // Sort matches to prioritize perfect matches
+  const sortedMatches = matches.sort((a, b) => {
+    const aNameLower = a.name.toLowerCase();
+    const bNameLower = b.name.toLowerCase();
+    const aNameJa = a.name_ja?.toLowerCase();
+    const bNameJa = b.name_ja?.toLowerCase();
+
+    // Check for perfect matches in English name
+    const aExactMatch = aNameLower === searchTerm;
+    const bExactMatch = bNameLower === searchTerm;
+
+    // Check for perfect matches in Japanese name
+    const aExactMatchJa = aNameJa === searchTerm;
+    const bExactMatchJa = bNameJa === searchTerm;
+
+    // Perfect matches (either English or Japanese) come first
+    if ((aExactMatch || aExactMatchJa) && !(bExactMatch || bExactMatchJa)) {
+      return -1;
+    }
+    if ((bExactMatch || bExactMatchJa) && !(aExactMatch || aExactMatchJa)) {
+      return 1;
+    }
+
+    // If both or neither are perfect matches, maintain original order
+    return 0;
+  });
+
   return {
-    cards: matches.slice(0, limit),
-    total: matches.length,
+    cards: sortedMatches.slice(0, limit),
+    total: sortedMatches.length,
   };
 }
 


### PR DESCRIPTION
## Summary
If there's a perfect match for the search query (case insensitive), show that card on the top of the list instead of below other partial matches.

## Implementation
- **Server-side sorting** in the API's searchCards function
- **Perfect match detection** for both English and Japanese card names
- **Case insensitive matching** for better user experience
- **Maintains original order** for non-perfect matches

## Technical Details
- Modified `searchCards()` in `/apps/api/src/data.ts`
- Added sorting logic after filtering to prioritize exact matches
- Checks both `name` and `name_ja` fields for perfect matches
- Uses stable sort to preserve original ordering for tied results

## Testing
- ✅ API builds successfully
- ✅ Web app builds without issues
- ✅ Perfect matches will now appear first in search results

## Example
Before: Searching "Lightning Bolt" might show partial matches first
After: "Lightning Bolt" (exact match) will always appear at the top

Close #3