### PR TITLE
Add Vercel Analytics

### DIFF
--- a/apps/web/app/root.tsx
+++ b/apps/web/app/root.tsx
@@ -7,6 +7,7 @@ import {
 } from "@remix-run/react";
 import { ThemeProvider } from "./contexts/ThemeContext";
 import { BodyStyle } from "./components/BodyStyle";
+import { Analytics } from "@vercel/analytics/remix";
 
 export default function App() {
   return (
@@ -18,8 +19,9 @@ export default function App() {
         <Links />
       </head>
       <body>
-        <style dangerouslySetInnerHTML={{
-          __html: `
+        <style
+          dangerouslySetInnerHTML={{
+            __html: `
             * {
               box-sizing: border-box;
             }
@@ -47,14 +49,16 @@ export default function App() {
                 transition: none !important;
               }
             }
-          `
-        }} />
+          `,
+          }}
+        />
         <ThemeProvider>
           <BodyStyle />
           <Outlet />
         </ThemeProvider>
         <ScrollRestoration />
         <Scripts />
+        <Analytics />
       </body>
     </html>
   );

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,7 @@
     "@remix-run/node": "^2.0.0",
     "@remix-run/react": "^2.0.0",
     "@remix-run/serve": "^2.0.0",
+    "@vercel/analytics": "^1.5.0",
     "@vercel/remix": "^2.16.6",
     "i18next": "^25.2.1",
     "i18next-browser-languagedetector": "^8.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       '@remix-run/serve':
         specifier: ^2.0.0
         version: 2.16.8(typescript@5.8.3)
+      '@vercel/analytics':
+        specifier: ^1.5.0
+        version: 1.5.0(@remix-run/react@2.16.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3))(react@18.3.1)
       '@vercel/remix':
         specifier: ^2.16.6
         version: 2.16.6(@remix-run/dev@2.16.8(@remix-run/react@2.16.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3))(@remix-run/serve@2.16.8(typescript@5.8.3))(@types/node@20.19.0)(typescript@5.8.3)(vite@5.4.19(@types/node@20.19.0)))(@remix-run/node@2.16.8(typescript@5.8.3))(@remix-run/server-runtime@2.16.8(typescript@5.8.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1023,6 +1026,32 @@ packages:
 
   '@vanilla-extract/private@1.0.9':
     resolution: {integrity: sha512-gT2jbfZuaaCLrAxwXbRgIhGhcXbRZCG3v4TTUnjw0EJ7ArdBRxkq4msNJkbuRkCgfIK5ATmprB5t9ljvLeFDEA==}
+
+  '@vercel/analytics@1.5.0':
+    resolution: {integrity: sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g==}
+    peerDependencies:
+      '@remix-run/react': ^2
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   '@vercel/remix@2.16.6':
     resolution: {integrity: sha512-TfnxoU7iUo41CzPqqGMWF/+Jyt2n2H/uEhaV+C6upfJbD25dBkjr0LswA+E5mWsZrweqxfir1ALM5ljxRXnuGQ==}
@@ -3959,6 +3988,11 @@ snapshots:
       - terser
 
   '@vanilla-extract/private@1.0.9': {}
+
+  '@vercel/analytics@1.5.0(@remix-run/react@2.16.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3))(react@18.3.1)':
+    optionalDependencies:
+      '@remix-run/react': 2.16.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      react: 18.3.1
 
   '@vercel/remix@2.16.6(@remix-run/dev@2.16.8(@remix-run/react@2.16.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3))(@remix-run/serve@2.16.8(typescript@5.8.3))(@types/node@20.19.0)(typescript@5.8.3)(vite@5.4.19(@types/node@20.19.0)))(@remix-run/node@2.16.8(typescript@5.8.3))(@remix-run/server-runtime@2.16.8(typescript@5.8.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:


### PR DESCRIPTION
## Summary
- Install @vercel/analytics package for web analytics tracking
- Import Analytics component from @vercel/analytics/remix
- Add Analytics component before closing body tag as recommended by Vercel

## Changes
- Added @vercel/analytics dependency to package.json
- Imported Analytics component in root.tsx
- Positioned Analytics component at the end of body for optimal loading

Close #32