### PR TITLE
Consolidate duplicate MagicCard interface definitions

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,7 +15,8 @@
     "hono": "^4.0.0",
     "graphql": "^16.8.0",
     "graphql-yoga": "^5.0.0",
-    "@hono/node-server": "^1.0.0"
+    "@hono/node-server": "^1.0.0",
+    "@mtg-middle-school/shared-types": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/apps/api/src/csv-to-json.ts
+++ b/apps/api/src/csv-to-json.ts
@@ -1,50 +1,9 @@
 import { readFileSync, writeFileSync, mkdirSync } from "fs";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
+import type { MagicCard, PartialMagicCard } from "@mtg-middle-school/shared-types";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-
-interface MagicCard {
-  oracle_id: string;
-  name: string;
-  name_ja: string | null;
-  banned: boolean;
-  mv: number;
-  rarity: string;
-  text: string;
-  type: string;
-  power: string | null;
-  toughness: string | null;
-  w: boolean;
-  u: boolean;
-  b: boolean;
-  r: boolean;
-  g: boolean;
-  c: boolean;
-  image_small: string;
-}
-
-// Partial card interface for parsing (allows gradual property assignment)
-interface PartialMagicCard {
-  oracle_id?: string;
-  name?: string;
-  name_ja?: string | null;
-  banned?: boolean;
-  mv?: number;
-  rarity?: string;
-  text?: string;
-  type?: string;
-  power?: string | null;
-  toughness?: string | null;
-  w?: boolean;
-  u?: boolean;
-  b?: boolean;
-  r?: boolean;
-  g?: boolean;
-  c?: boolean;
-  image_small?: string;
-  [key: string]: unknown; // Allow additional properties during parsing
-}
 
 function parseCSVRecords(csvContent: string): string[] {
   const records: string[] = [];

--- a/apps/api/src/data.ts
+++ b/apps/api/src/data.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "fs";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
-import type { MagicCard } from "./types.js";
+import type { MagicCard } from "@mtg-middle-school/shared-types";
 
 // Handle both ES modules and CommonJS
 const getCurrentDir = (): string => {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { createYoga, createSchema } from "graphql-yoga";
 import { searchCards, getCardById, getCardsByColor, validateCards } from "./data.js";
-import type { MagicCard } from "./types.js";
+import type { MagicCard } from "@mtg-middle-school/shared-types";
 import { pathToFileURL } from "url";
 
 // GraphQL resolver types

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -1,24 +1,2 @@
-export interface MagicCard {
-  oracle_id: string;
-  name: string;
-  name_ja: string | null;
-  banned: boolean;
-  mv: number;
-  rarity: string;
-  text: string;
-  type: string;
-  power: string | null;
-  toughness: string | null;
-  w: boolean;
-  u: boolean;
-  b: boolean;
-  r: boolean;
-  g: boolean;
-  c: boolean;
-  image_small: string;
-}
-
-export interface CardSearchResult {
-  cards: MagicCard[];
-  total: number;
-}
+// This file now exports from shared types package
+export type { MagicCard, CardSearchResult } from "@mtg-middle-school/shared-types";

--- a/apps/web/app/components/CardList.tsx
+++ b/apps/web/app/components/CardList.tsx
@@ -1,5 +1,5 @@
 import { useRef, useEffect, useState } from "react";
-import type { MagicCard } from "../lib/types";
+import type { MagicCard } from "@mtg-middle-school/shared-types";
 import { generateScryfallUrl } from "../lib/utils";
 import { useThemedStyles } from "../hooks/useTheme";
 import { useHydratedTranslation } from "../hooks/useHydratedTranslation";

--- a/apps/web/app/lib/api.ts
+++ b/apps/web/app/lib/api.ts
@@ -1,4 +1,4 @@
-import type { CardSearchResult, SearchParams } from "./types";
+import type { CardSearchResult, SearchParams } from "@mtg-middle-school/shared-types";
 
 const API_URL = process.env.API_URL || "http://localhost:3001/graphql";
 

--- a/apps/web/app/lib/deck-parser.ts
+++ b/apps/web/app/lib/deck-parser.ts
@@ -1,4 +1,4 @@
-import type { DeckEntry } from "./types";
+import type { DeckEntry } from "@mtg-middle-school/shared-types";
 
 export function parseDeckList(deckListText: string): DeckEntry[] {
   const lines = deckListText

--- a/apps/web/app/lib/types.ts
+++ b/apps/web/app/lib/types.ts
@@ -1,52 +1,8 @@
-export interface MagicCard {
-  oracle_id: string;
-  name: string;
-  name_ja: string | null;
-  banned: boolean;
-  mv: number;
-  rarity: string;
-  text: string;
-  type: string;
-  power: string | null;
-  toughness: string | null;
-  w: boolean;
-  u: boolean;
-  b: boolean;
-  r: boolean;
-  g: boolean;
-  c: boolean;
-  perfectMatch?: boolean;
-  image_small: string;
-}
-
-export interface CardSearchResult {
-  cards: MagicCard[];
-  total: number;
-}
-
-export interface DeckEntry {
-  quantity: number;
-  name: string;
-}
-
-export interface DeckValidationResult {
-  name: string;
-  quantity: number;
-  found: boolean;
-  banned: boolean;
-  matchedName: string | null;
-  matchedNameJa: string | null;
-}
-
-export interface SearchParams {
-  query: string;
-  cardType?: string;
-  colors?: string[];
-  limit?: number;
-  powerMin?: number;
-  powerMax?: number;
-  toughnessMin?: number;
-  toughnessMax?: number;
-  cmcMin?: number;
-  cmcMax?: number;
-}
+// This file now exports from shared types package
+export type { 
+  MagicCard, 
+  CardSearchResult, 
+  DeckEntry, 
+  DeckValidationResult, 
+  SearchParams 
+} from "@mtg-middle-school/shared-types";

--- a/apps/web/app/routes/_index/loader.ts
+++ b/apps/web/app/routes/_index/loader.ts
@@ -1,7 +1,7 @@
 import type { LoaderFunctionArgs } from "@remix-run/node";
 import { json } from "@remix-run/node";
 import { searchCards } from "../../lib/api";
-import type { CardSearchResult } from "../../lib/types";
+import type { CardSearchResult } from "@mtg-middle-school/shared-types";
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const url = new URL(request.url);

--- a/apps/web/app/routes/deck-check/loader.ts
+++ b/apps/web/app/routes/deck-check/loader.ts
@@ -2,7 +2,7 @@ import type { LoaderFunctionArgs } from "@remix-run/node";
 import { json } from "@remix-run/node";
 import { validateCards } from "../../lib/api";
 import { parseDeckList } from "../../lib/deck-parser";
-import type { DeckValidationResult } from "../../lib/types";
+import type { DeckValidationResult } from "@mtg-middle-school/shared-types";
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const url = new URL(request.url);

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,7 +22,8 @@
     "isbot": "^4.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-i18next": "^15.5.3"
+    "react-i18next": "^15.5.3",
+    "@mtg-middle-school/shared-types": "workspace:*"
   },
   "devDependencies": {
     "@remix-run/dev": "^2.0.0",

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@mtg-middle-school/shared-types",
+  "version": "1.0.0",
+  "description": "Shared TypeScript interfaces for MTG Middle School applications",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
+    }
+  }
+}

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -1,0 +1,76 @@
+// Shared TypeScript interfaces for MTG Middle School applications
+
+export interface MagicCard {
+  oracle_id: string;
+  name: string;
+  name_ja: string | null;
+  banned: boolean;
+  mv: number;
+  rarity: string;
+  text: string;
+  type: string;
+  power: string | null;
+  toughness: string | null;
+  w: boolean;
+  u: boolean;
+  b: boolean;
+  r: boolean;
+  g: boolean;
+  c: boolean;
+  perfectMatch?: boolean;
+  image_small: string;
+}
+
+export interface CardSearchResult {
+  cards: MagicCard[];
+  total: number;
+}
+
+export interface DeckEntry {
+  quantity: number;
+  name: string;
+}
+
+export interface DeckValidationResult {
+  name: string;
+  quantity: number;
+  found: boolean;
+  banned: boolean;
+  matchedName: string | null;
+  matchedNameJa: string | null;
+}
+
+export interface SearchParams {
+  query: string;
+  cardType?: string;
+  colors?: string[];
+  limit?: number;
+  powerMin?: number;
+  powerMax?: number;
+  toughnessMin?: number;
+  toughnessMax?: number;
+  cmcMin?: number;
+  cmcMax?: number;
+}
+
+// Partial card interface for parsing (allows gradual property assignment)
+export interface PartialMagicCard {
+  oracle_id?: string;
+  name?: string;
+  name_ja?: string | null;
+  banned?: boolean;
+  mv?: number;
+  rarity?: string;
+  text?: string;
+  type?: string;
+  power?: string | null;
+  toughness?: string | null;
+  w?: boolean;
+  u?: boolean;
+  b?: boolean;
+  r?: boolean;
+  g?: boolean;
+  c?: boolean;
+  image_small?: string;
+  [key: string]: unknown; // Allow additional properties during parsing
+}

--- a/packages/shared-types/tsconfig.json
+++ b/packages/shared-types/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@hono/node-server':
         specifier: ^1.0.0
         version: 1.14.4(hono@4.7.11)
+      '@mtg-middle-school/shared-types':
+        specifier: workspace:*
+        version: link:../../packages/shared-types
       graphql:
         specifier: ^16.8.0
         version: 16.11.0
@@ -39,6 +42,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@mtg-middle-school/shared-types':
+        specifier: workspace:*
+        version: link:../../packages/shared-types
       '@remix-run/node':
         specifier: ^2.0.0
         version: 2.16.8(typescript@5.8.3)
@@ -88,6 +94,12 @@ importers:
       vite:
         specifier: ^5.1.0
         version: 5.4.19(@types/node@20.19.0)
+
+  packages/shared-types:
+    devDependencies:
+      typescript:
+        specifier: ^5.0.0
+        version: 5.8.3
 
 packages:
 


### PR DESCRIPTION
## Summary
- Eliminate duplicate MagicCard interface definitions across the codebase
- Create centralized shared types package for better maintainability
- Ensure consistent type definitions across API and web applications

## Changes Made
- **Shared Types Package**: Created `@mtg-middle-school/shared-types` as a proper workspace package
- **Consolidated Interfaces**: Moved all type definitions to a single location in `packages/shared-types/src/index.ts`
- **Updated Dependencies**: Added shared types package to both API and web app dependencies
- **Import Updates**: Updated all imports across 11 files to reference the shared package
- **Backward Compatibility**: Kept existing type files as re-exports to avoid breaking changes

## Types Consolidated
- `MagicCard` (using web version with `perfectMatch?: boolean` field)
- `CardSearchResult`, `DeckEntry`, `DeckValidationResult`, `SearchParams`
- `PartialMagicCard` for CSV parsing operations

## Benefits
- ✅ Single source of truth for all type definitions
- ✅ Eliminates duplication and potential inconsistencies
- ✅ Better maintainability and easier updates
- ✅ Proper monorepo architecture with shared packages
- ✅ All TypeScript compilation and builds pass

Close #40