### PR TITLE
Consolidate MagicCard interfaces (Vercel-compatible)

### DIFF
--- a/apps/api/src/csv-to-json.ts
+++ b/apps/api/src/csv-to-json.ts
@@ -1,50 +1,9 @@
 import { readFileSync, writeFileSync, mkdirSync } from "fs";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
+import type { MagicCard, PartialMagicCard } from "./types.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-
-interface MagicCard {
-  oracle_id: string;
-  name: string;
-  name_ja: string | null;
-  banned: boolean;
-  mv: number;
-  rarity: string;
-  text: string;
-  type: string;
-  power: string | null;
-  toughness: string | null;
-  w: boolean;
-  u: boolean;
-  b: boolean;
-  r: boolean;
-  g: boolean;
-  c: boolean;
-  image_small: string;
-}
-
-// Partial card interface for parsing (allows gradual property assignment)
-interface PartialMagicCard {
-  oracle_id?: string;
-  name?: string;
-  name_ja?: string | null;
-  banned?: boolean;
-  mv?: number;
-  rarity?: string;
-  text?: string;
-  type?: string;
-  power?: string | null;
-  toughness?: string | null;
-  w?: boolean;
-  u?: boolean;
-  b?: boolean;
-  r?: boolean;
-  g?: boolean;
-  c?: boolean;
-  image_small?: string;
-  [key: string]: unknown; // Allow additional properties during parsing
-}
 
 function parseCSVRecords(csvContent: string): string[] {
   const records: string[] = [];

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -15,10 +15,34 @@ export interface MagicCard {
   r: boolean;
   g: boolean;
   c: boolean;
+  perfectMatch?: boolean;
   image_small: string;
 }
 
 export interface CardSearchResult {
   cards: MagicCard[];
   total: number;
+}
+
+// Partial card interface for parsing (allows gradual property assignment)
+export interface PartialMagicCard {
+  oracle_id?: string;
+  name?: string;
+  name_ja?: string | null;
+  banned?: boolean;
+  mv?: number;
+  rarity?: string;
+  text?: string;
+  type?: string;
+  power?: string | null;
+  toughness?: string | null;
+  w?: boolean;
+  u?: boolean;
+  b?: boolean;
+  r?: boolean;
+  g?: boolean;
+  c?: boolean;
+  perfectMatch?: boolean;
+  image_small?: string;
+  [key: string]: unknown; // Allow additional properties during parsing
 }


### PR DESCRIPTION
## Summary
- Fix duplicate MagicCard interface definitions with Vercel-compatible approach
- Ensure both API and web apps use identical interface definitions
- Eliminate code duplication while maintaining separate deployability

## Problem Solved
The previous approach using workspace dependencies (`workspace:*`) doesn't work on Vercel when API and web are deployed as separate projects. Each Vercel deployment only sees its own app directory, not the entire monorepo.

## Solution
Instead of creating a shared package, this consolidates types within each app:
- **API**: Updated MagicCard interface to match web version (added `perfectMatch` field)
- **API**: Moved PartialMagicCard from csv-to-json.ts to central types.ts file  
- **CSV Parser**: Now imports types from central types.ts instead of defining its own

## Changes Made
- ✅ **Unified interfaces**: Both API and web now use identical MagicCard interface
- ✅ **Added missing field**: API interface now includes `perfectMatch?: boolean`
- ✅ **Centralized parsing types**: PartialMagicCard moved to api/src/types.ts
- ✅ **Eliminated duplication**: Removed duplicate interface in csv-to-json.ts
- ✅ **Vercel-compatible**: No workspace dependencies, each app is self-contained

## Benefits
- 🚀 **Vercel deployment works**: No workspace dependencies to break deployment
- 🔧 **Type consistency**: Identical interfaces across API and web
- 📦 **Reduced duplication**: Single source of truth within each app
- 🛡️ **Type safety**: Proper TypeScript interfaces throughout

Close #40