### PR TITLE
Replace deprecated json() function in loaders

### DIFF
--- a/apps/web/app/components/ExpandableCardRow.tsx
+++ b/apps/web/app/components/ExpandableCardRow.tsx
@@ -95,7 +95,6 @@ export function ExpandableCardRow({ result, index, isJapanese = false, isLast = 
             icon={Ban} 
             size="sm" 
             color={colors.accent.red}
-            title={t("bannedLabel")}
           />
         )}
         {!result.found && (
@@ -103,7 +102,6 @@ export function ExpandableCardRow({ result, index, isJapanese = false, isLast = 
             icon={MessageCircleQuestion} 
             size="sm" 
             color={colors.accent.orange}
-            title={t("notFound")}
           />
         )}
       </div>

--- a/apps/web/app/routes/_index/loader.ts
+++ b/apps/web/app/routes/_index/loader.ts
@@ -1,5 +1,4 @@
 import type { LoaderFunctionArgs } from "@remix-run/node";
-import { json } from "@remix-run/node";
 import { searchCards } from "../../lib/api";
 import type { CardSearchResult } from "../../lib/types";
 
@@ -46,7 +45,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   if (!query || query.trim() === "") {
     // If no query and no filters, show empty state
     if (!hasFilters) {
-      return json({
+      return {
         searchResult: null,
         query: "",
         cardType,
@@ -60,7 +59,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
         page: 1,
         totalPages: 0,
         error: null,
-      });
+      };
     }
     // If filters but no query, search with empty query (will return filtered results)
   }
@@ -80,7 +79,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
       cmcMin !== 0 || cmcMax !== 16 ? cmcMin : undefined,
       cmcMin !== 0 || cmcMax !== 16 ? cmcMax : undefined
     );
-    return json({
+    return {
       searchResult,
       query,
       cardType,
@@ -94,10 +93,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
       page,
       totalPages: Math.ceil(searchResult.total / limit),
       error: null,
-    });
+    };
   } catch (error) {
     console.error("Search error:", error);
-    return json({
+    return {
       searchResult: { cards: [], total: 0 } as CardSearchResult,
       query,
       cardType,
@@ -111,6 +110,6 @@ export async function loader({ request }: LoaderFunctionArgs) {
       page,
       totalPages: 0,
       error: "searchError", // Pass translation key instead of hardcoded text
-    });
+    };
   }
 }

--- a/apps/web/app/routes/deck-check/loader.ts
+++ b/apps/web/app/routes/deck-check/loader.ts
@@ -1,5 +1,4 @@
 import type { LoaderFunctionArgs } from "@remix-run/node";
-import { json } from "@remix-run/node";
 import { validateCards, searchCards } from "../../lib/api";
 import { parseDeckList } from "../../lib/deck-parser";
 import type { DeckValidationResult } from "../../lib/types";
@@ -9,17 +8,17 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const deckList = url.searchParams.get("decklist");
 
   if (!deckList || deckList.trim() === "") {
-    return json({ results: null, deckList: "", error: null });
+    return { results: null, deckList: "", error: null };
   }
 
   // Check line count before processing
   const lines = deckList.split('\n').filter(line => line.trim().length > 0);
   if (lines.length > 100) {
-    return json({
+    return {
       results: null,
       deckList,
       error: "deckLineLimitError",
-    });
+    };
   }
 
   try {
@@ -69,13 +68,13 @@ export async function loader({ request }: LoaderFunctionArgs) {
       };
     });
 
-    return json({ results, deckList, error: null });
+    return { results, deckList, error: null };
   } catch (error) {
     console.error("Deck validation error:", error);
-    return json({
+    return {
       results: null,
       deckList,
       error: "deckValidationError",
-    });
+    };
   }
 }


### PR DESCRIPTION
## Summary
- Remove deprecated `json()` function imports from loader files
- Return plain objects directly instead of `json()` wrapped responses
- Fix TypeScript errors with Icon component title props

## Test plan
- [x] TypeScript checks pass
- [x] Build completes successfully
- [x] Functionality preserved (loaders return same data structure)

Close #58