### PR TITLE
Remove rarity field from MagicCard data model

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -72,7 +72,6 @@ const typeDefs = `
     name_ja: String
     banned: Boolean!
     mv: Int!
-    rarity: String!
     text: String!
     type: String!
     power: String

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -4,7 +4,6 @@ export interface MagicCard {
   name_ja: string | null;
   banned: boolean;
   mv: number;
-  rarity: string;
   text: string;
   type: string;
   power: string | null;
@@ -31,7 +30,6 @@ export interface PartialMagicCard {
   name_ja?: string | null;
   banned?: boolean;
   mv?: number;
-  rarity?: string;
   text?: string;
   type?: string;
   power?: string | null;

--- a/apps/web/app/components/StyledButton.test.tsx
+++ b/apps/web/app/components/StyledButton.test.tsx
@@ -2,11 +2,123 @@ import { describe, test, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Search, Download } from "lucide-react";
-import { StyledButton } from "./StyledButton";
-import { mockUseTheme } from "../test-utils/theme-mocks";
 
-// Mock the theme hooks since they depend on context providers
-mockUseTheme();
+// Mock the theme hooks at the top level
+vi.mock("../contexts/ThemeContext", () => ({
+  useTheme: () => ({
+    mode: "light",
+    colors: {
+      button: {
+        primary: "#3B82F6",
+        text: "#FFFFFF",
+        disabled: "#9CA3AF",
+      },
+      background: {
+        primary: "#FFFFFF",
+        secondary: "#F3F4F6",
+        card: "#FFFFFF",
+      },
+      text: {
+        primary: "#111827",
+        secondary: "#6B7280",
+        link: "#3B82F6",
+        error: "#EF4444",
+      },
+      border: {
+        primary: "#D1D5DB",
+        error: "#EF4444",
+      },
+    },
+    setTheme: vi.fn(),
+  }),
+}));
+
+vi.mock("../hooks/useTheme", () => ({
+  useThemedStyles: () => ({
+    colors: {
+      button: {
+        primary: "#3B82F6",
+        text: "#FFFFFF",
+        disabled: "#9CA3AF",
+      },
+      background: {
+        primary: "#FFFFFF",
+        secondary: "#F3F4F6",
+        card: "#FFFFFF",
+      },
+      text: {
+        primary: "#111827",
+        secondary: "#6B7280",
+        link: "#3B82F6",
+        error: "#EF4444",
+      },
+      border: {
+        primary: "#D1D5DB",
+        error: "#EF4444",
+      },
+    },
+    utilities: {
+      borderRadius: (_size: string) => "8px",
+      transition: (prop: string) => `${prop} 0.2s ease`,
+      spacing: (size: string) => {
+        const sizes = {
+          xs: "4px",
+          sm: "8px",
+          md: "12px",
+          lg: "16px",
+          xl: "20px",
+          "2xl": "24px",
+        };
+        return sizes[size as keyof typeof sizes] || "12px";
+      },
+      fontSize: (size: string) => {
+        const sizes = {
+          xs: "12px",
+          sm: "14px",
+          base: "16px",
+          lg: "18px",
+          xl: "20px",
+        };
+        return sizes[size as keyof typeof sizes] || "16px";
+      },
+    },
+  }),
+  useDesignTokens: () => ({
+    typography: {
+      fontWeight: {
+        medium: "500",
+      },
+    },
+  }),
+  useTheme: () => ({
+    mode: "light",
+    colors: {
+      button: {
+        primary: "#3B82F6",
+        text: "#FFFFFF",
+        disabled: "#9CA3AF",
+      },
+      background: {
+        primary: "#FFFFFF",
+        secondary: "#F3F4F6",
+        card: "#FFFFFF",
+      },
+      text: {
+        primary: "#111827",
+        secondary: "#6B7280",
+        link: "#3B82F6",
+        error: "#EF4444",
+      },
+      border: {
+        primary: "#D1D5DB",
+        error: "#EF4444",
+      },
+    },
+    setTheme: vi.fn(),
+  }),
+}));
+
+import { StyledButton } from "./StyledButton";
 
 describe("StyledButton", () => {
   describe("Rendering", () => {

--- a/apps/web/app/lib/api.ts
+++ b/apps/web/app/lib/api.ts
@@ -1,4 +1,4 @@
-import type { CardSearchResult, } from "./types";
+import type { CardSearchResult } from "./types";
 
 const API_URL = process.env.API_URL || "http://localhost:3001/graphql";
 
@@ -30,7 +30,6 @@ export async function searchCards(
               name_ja
               banned
               mv
-              rarity
               text
               type
               power
@@ -48,7 +47,19 @@ export async function searchCards(
           }
         }
       `,
-      variables: { query, cardType, colors, limit, offset, powerMin, powerMax, toughnessMin, toughnessMax, cmcMin, cmcMax },
+      variables: {
+        query,
+        cardType,
+        colors,
+        limit,
+        offset,
+        powerMin,
+        powerMax,
+        toughnessMin,
+        toughnessMax,
+        cmcMin,
+        cmcMax,
+      },
     }),
   });
 
@@ -67,7 +78,15 @@ export async function searchCards(
 
 export async function validateCards(
   cardNames: string[]
-): Promise<Array<{ name: string; found: boolean; banned: boolean; matchedName: string | null; matchedNameJa: string | null }>> {
+): Promise<
+  Array<{
+    name: string;
+    found: boolean;
+    banned: boolean;
+    matchedName: string | null;
+    matchedNameJa: string | null;
+  }>
+> {
   const response = await fetch(API_URL, {
     method: "POST",
     headers: {
@@ -101,4 +120,3 @@ export async function validateCards(
 
   return data.data.validateCards;
 }
-

--- a/apps/web/app/lib/types.ts
+++ b/apps/web/app/lib/types.ts
@@ -4,7 +4,6 @@ export interface MagicCard {
   name_ja: string | null;
   banned: boolean;
   mv: number;
-  rarity: string;
   text: string;
   type: string;
   power: string | null;

--- a/apps/web/app/routes/deck-check/route.tsx
+++ b/apps/web/app/routes/deck-check/route.tsx
@@ -398,7 +398,7 @@ export default function DeckCheck() {
               >
                 {results.map((result, index) => (
                   <ExpandableCardRow
-                    key={`${result.input}-${result.found ? "found" : "not-found"}-${index}`}
+                    key={`${result.name}-${result.found ? "found" : "not-found"}-${index}`}
                     result={result}
                     index={index}
                     isJapanese={i18n.language === "ja"}

--- a/apps/web/app/test-utils/theme-mocks.ts
+++ b/apps/web/app/test-utils/theme-mocks.ts
@@ -1,48 +1,123 @@
-import { vi } from 'vitest'
+import { vi } from "vitest";
 
 /**
  * Mock implementation for useTheme hooks used in component tests
  * This provides consistent theme values for testing components that depend on theme context
  */
 export const mockUseTheme = () => {
-  vi.mock('../hooks/useTheme', () => ({
+  // Mock the ThemeContext first
+  vi.mock("../contexts/ThemeContext", () => ({
+    useTheme: () => ({
+      mode: "light",
+      colors: {
+        button: {
+          primary: "#3B82F6",
+          text: "#FFFFFF",
+          disabled: "#9CA3AF",
+        },
+        background: {
+          primary: "#FFFFFF",
+          secondary: "#F3F4F6",
+          card: "#FFFFFF",
+        },
+        text: {
+          primary: "#111827",
+          secondary: "#6B7280",
+          link: "#3B82F6",
+          error: "#EF4444",
+        },
+        border: {
+          primary: "#D1D5DB",
+          error: "#EF4444",
+        },
+      },
+      setTheme: vi.fn(),
+    }),
+  }));
+
+  // Mock the useTheme hooks
+  vi.mock("../hooks/useTheme", () => ({
     useThemedStyles: () => ({
       colors: {
         button: {
-          primary: '#3B82F6',
-          text: '#FFFFFF',
-          disabled: '#9CA3AF',
+          primary: "#3B82F6",
+          text: "#FFFFFF",
+          disabled: "#9CA3AF",
         },
         background: {
-          primary: '#FFFFFF',
-          secondary: '#F3F4F6',
+          primary: "#FFFFFF",
+          secondary: "#F3F4F6",
+          card: "#FFFFFF",
         },
         text: {
-          primary: '#111827',
+          primary: "#111827",
+          secondary: "#6B7280",
+          link: "#3B82F6",
+          error: "#EF4444",
         },
         border: {
-          primary: '#D1D5DB',
+          primary: "#D1D5DB",
+          error: "#EF4444",
         },
       },
       utilities: {
-        borderRadius: (_size: string) => '8px',
+        borderRadius: (_size: string) => "8px",
         transition: (prop: string) => `${prop} 0.2s ease`,
         spacing: (size: string) => {
-          const sizes = { xs: '4px', sm: '8px', md: '12px', lg: '16px', xl: '20px', '2xl': '24px' }
-          return sizes[size as keyof typeof sizes] || '12px'
+          const sizes = {
+            xs: "4px",
+            sm: "8px",
+            md: "12px",
+            lg: "16px",
+            xl: "20px",
+            "2xl": "24px",
+          };
+          return sizes[size as keyof typeof sizes] || "12px";
         },
         fontSize: (size: string) => {
-          const sizes = { xs: '12px', sm: '14px', base: '16px', lg: '18px', xl: '20px' }
-          return sizes[size as keyof typeof sizes] || '16px'
+          const sizes = {
+            xs: "12px",
+            sm: "14px",
+            base: "16px",
+            lg: "18px",
+            xl: "20px",
+          };
+          return sizes[size as keyof typeof sizes] || "16px";
         },
       },
     }),
     useDesignTokens: () => ({
       typography: {
         fontWeight: {
-          medium: '500',
+          medium: "500",
         },
       },
     }),
-  }))
-}
+    useTheme: () => ({
+      mode: "light",
+      colors: {
+        button: {
+          primary: "#3B82F6",
+          text: "#FFFFFF",
+          disabled: "#9CA3AF",
+        },
+        background: {
+          primary: "#FFFFFF",
+          secondary: "#F3F4F6",
+          card: "#FFFFFF",
+        },
+        text: {
+          primary: "#111827",
+          secondary: "#6B7280",
+          link: "#3B82F6",
+          error: "#EF4444",
+        },
+        border: {
+          primary: "#D1D5DB",
+          error: "#EF4444",
+        },
+      },
+      setTheme: vi.fn(),
+    }),
+  }));
+};


### PR DESCRIPTION
## Summary
- Remove the `rarity` field from MagicCard interface and related data structures
- Remove rarity from GraphQL schema and API queries
- Fix typecheck error in deck-check route (`result.input` → `result.name`)
- Improve theme test mocks to fix ThemeProvider test setup

## Changes Made
- **API Types**: Removed `rarity` field from `MagicCard` and `PartialMagicCard` interfaces
- **Web Types**: Removed `rarity` field from `MagicCard` interface
- **GraphQL Schema**: Removed `rarity: String\!` from MagicCard type definition
- **API Query**: Removed `rarity` field from searchCards GraphQL query
- **Data**: Removed rarity field from all ~5,800 card entries in cards.json (excluded from git)
- **Bug Fix**: Fixed typecheck error in deck-check route by changing `result.input` to `result.name`
- **Test Improvement**: Fixed ThemeProvider test setup by moving mocks to test file level

## Test Results
- ✅ All API tests pass (15/15)
- ✅ All web tests pass (41/41)
- ✅ TypeScript compilation successful
- ✅ All existing functionality preserved

## Risk Assessment
**Low Risk** - The rarity field was not being used in any UI components or business logic. Removing it simplifies the data model and reduces payload size without affecting functionality.

Close #66